### PR TITLE
[수정] 날짜 구분선 렌더링 방식 개선

### DIFF
--- a/src/components/DateDivider.tsx
+++ b/src/components/DateDivider.tsx
@@ -1,5 +1,3 @@
-import { ChatMessage } from "../util/groupByMinute";
-import GroupedByMin from "./GroupedByMin";
 import styled from "styled-components";
 
 const SContainer = styled.div`
@@ -33,20 +31,13 @@ const SContainer = styled.div`
   }
 `;
 
-function GroupedByDate({ data }: { data: ChatMessage }) {
-  const parsedDate = data.datetime.split("-");
-  // TODO: 바로 전 데이터와 비교해서 다를 때에만 구분선 긋기
-
+function DateDivider({ date }: { date: string }) {
+  const slicedDate = date.split("-");
   return (
     <SContainer>
-      {/* <div id="line">
-        {`${parsedDate[0]}년 ${parsedDate[1]}월 ${parsedDate[2]}일`}
-      </div> */}
-      {/* {data.map((byMin, idx) => (
-        <GroupedByMin key={idx} data={byMin} />
-      ))} */}
+      <div id="line">{`${slicedDate[0]}년 ${slicedDate[1]}월 ${slicedDate[2]}일`}</div>
     </SContainer>
   );
 }
 
-export default GroupedByDate;
+export default DateDivider;

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -1,8 +1,9 @@
 import styled from "styled-components";
 import groupByMinute, { ChatMessage } from "../util/groupByMinute";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import useIntersect from "../hooks/useIntersect";
 import GroupedByMin from "../components/GroupedByMin";
+import DateDivider from "../components/DateDivider";
 
 const SChatContainer = styled.div`
   overflow: hidden;
@@ -30,7 +31,7 @@ function Chats() {
     })
       .then((res) => res.json())
       .then((res) => {
-        setData(Object.values(groupByMinute(res.slice(0, 40))));
+        setData(Object.values(groupByMinute(res.slice(0, 120))));
       });
   }, []);
 
@@ -59,8 +60,25 @@ function Chats() {
 
   return (
     <SChatContainer>
-      {data.map((el, idx) => {
-        return <GroupedByMin key={idx} data={el} />;
+      {data.map((el, idx, arr) => {
+        // index가 1 이상이고, arr.length를 초과하지 않아야 함.
+        let isDifferentDate;
+        if (idx >= 1 && idx < arr.length) {
+          isDifferentDate =
+            el[0].datetime.slice(0, 10) !==
+            arr[idx - 1][0].datetime.slice(0, 10)
+              ? true
+              : false;
+        }
+
+        return (
+          <React.Fragment key={idx}>
+            {isDifferentDate || idx === 0 ? (
+              <DateDivider date={el[0].datetime.slice(0, 10)} />
+            ) : null}
+            <GroupedByMin data={el} />
+          </React.Fragment>
+        );
       })}
       {/* <div ref={ref}></div> */}
     </SChatContainer>


### PR DESCRIPTION
#19 
이전 요소의 날짜와 현 요소의 날짜를 비교하여 다를 때에만 날짜 구분선을 표시한다. 
컴포넌트, 그리고 data의 depth를 줄이는 효과가 있었다.