### PR TITLE
[개선] 채팅 불러오는 속도 개선하기

### DIFF
--- a/src/app/chats/[id]/page.tsx
+++ b/src/app/chats/[id]/page.tsx
@@ -19,8 +19,8 @@ export default async function Chats(props: ChatProps) {
     <>
       <Navbar title={id} />
       <div id="chats">
-        {chat.map((el: ChatMessage[]) => {
-          return <GroupedByMin data={el} />;
+        {chat.map((el: ChatMessage[], idx: number) => {
+          return <GroupedByMin data={el} key={idx} />;
         })}
       </div>
     </>

--- a/src/pages/api/chat/[id].ts
+++ b/src/pages/api/chat/[id].ts
@@ -1,9 +1,45 @@
 // 날짜를 쿼리로 받아서 그 날짜에 해당하는 챗을 보내주는 핸들러
 import type { NextApiRequest, NextApiResponse } from "next";
 import data from "../../../../data.json";
+import { ChatMessage } from "@/components/Bubble";
+
+interface GroupedByDate {
+  date: string;
+  chats: ChatMessage[][];
+}
+
+const assertedData: GroupedByDate[] = data as GroupedByDate[];
+
+function binary_search(
+  arr: GroupedByDate[],
+  target: string,
+  start: number,
+  end: number
+) {
+  const targetDate = new Date(target);
+
+  while (start <= end) {
+    const mid = Math.floor((start + end) / 2);
+    const midDate = new Date(arr[mid].date);
+
+    if (String(midDate) === String(targetDate)) {
+      return arr[mid].chats;
+    } else if (midDate < targetDate) {
+      start = mid + 1;
+    } else {
+      end = mid - 1;
+    }
+  }
+}
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { id } = req.query;
-  const chat = data.filter((el) => el.date === String(id))[0];
-  res.status(200).json(chat.chats);
+
+  if (typeof id === "string") {
+    const chat = binary_search(assertedData, id, 0, assertedData.length - 1);
+    if (chat) res.status(200).json(chat);
+    else res.status(404).json({ error: "Chat not found" });
+  } else {
+    res.status(404).json({ error: "Invalid Date" });
+  }
 }


### PR DESCRIPTION
Closes #40 

### 참고
처음에 이분탐색으로 전환 후 요청을 보냈을 때 정상적으로 잘 오길래 잘 적용된 줄 알았는데 캐싱된 데이터가 계속 불러와졌던 거였다.
그래서 함수 자체에 오류가 있었던 것도 뒤늦게 알게 됨. 데이터 요청 시간이 유의미하게 줄어들었는지도 다시 봐야할 것 같다.  