### PR TITLE
[UI/UX] 방문한 채팅 제목 글자 흐리게 표시

### DIFF
--- a/src/components/ListItem.module.css
+++ b/src/components/ListItem.module.css
@@ -29,6 +29,10 @@
   left: 0;
 }
 
+.link:visited {
+  color: var(--gray);
+}
+
 .iconGroup {
   display: flex;
   align-items: center;


### PR DESCRIPTION
이미 본 채팅은 제목을 흐리게 표시해 사용자가 헷갈리지 않도록 한다. 